### PR TITLE
Fix AttributeError when using including the EXTINF

### DIFF
--- a/mkpl.py
+++ b/mkpl.py
@@ -644,7 +644,7 @@ def make_extinf(file):
         elif isinstance(file.tags, mp4.MP4Tags):
             artist = file.tags.get("\xa9ART", [""])[0]
             title = file.tags.get("\xa9nam", [""])[0]
-        return extinf_str.format(length, artist.replace(), title).replace("\n", " ")
+        return extinf_str.format(length, artist, title).replace("\n", " ")
     return "Unknown extra infos"
 
 

--- a/mkpl.py
+++ b/mkpl.py
@@ -79,7 +79,7 @@ VIDEO_FORMAT = {
 FILE_FORMAT = AUDIO_FORMAT.union(VIDEO_FORMAT)
 EXPLAIN_ERROR = False
 CACHE = TempCache("mkpl", max_age=30)
-__version__ = "1.18.0"
+__version__ = "1.18.1"
 
 Playlist = namedtuple(
     "Playlist", ("files", "ext", "name", "encoding"), defaults=([], False, False, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = ["mkpl"]
 
 [project]
 name = "make_playlist"
-version = "1.18.0"
+version = "1.18.1"
 readme = "README.md"
 keywords = ["playlist", "multimedia", "file", "maker", "make", "m3u", "m3u8"]
 


### PR DESCRIPTION
# Fix AttributeError when using including the EXTINF 

## List of changes

- ✅ `Remove the call to replace() in the make_extinf function`
- ✅ `Patch version bump in the pyproject.toml and mkpl.py`

### Description of the proposed features

When including the EXTINF information in the playlist I was getting an AttributeError. In the `make_extinf` function in the return statement `replace()` was being called on the `artist` object with no arguments. The `artist` object doesn't have a `replace()` method. Removing this errant call fixes the function. Tested with MP3 and MP4 files and it works as expected.
